### PR TITLE
Ajout annotation XXXMapping, pour les requêtes http classiques (get, …

### DIFF
--- a/src/core/src/decorators/DeleteMapping.ts
+++ b/src/core/src/decorators/DeleteMapping.ts
@@ -1,0 +1,10 @@
+import 'reflect-metadata';
+
+export function DeleteMapping(value: any): MethodDecorator {
+  return (target: any, property: string | symbol, descriptor: PropertyDescriptor) => {
+    value.functionName = property;
+    const listMapping = Reflect.getMetadata('DeleteMapping', target) || [];
+    listMapping.push(value);
+    Reflect.defineMetadata('DeleteMapping', listMapping, target);
+  };
+}

--- a/src/core/src/decorators/GetMapping.ts
+++ b/src/core/src/decorators/GetMapping.ts
@@ -1,0 +1,10 @@
+import 'reflect-metadata';
+
+export function GetMapping(value: any): MethodDecorator {
+  return (target: any, property: string | symbol, descriptor: PropertyDescriptor) => {
+    value.functionName = property;
+    const listMapping = Reflect.getMetadata('GetMapping', target) || [];
+    listMapping.push(value);
+    Reflect.defineMetadata('GetMapping', listMapping, target);
+  };
+}

--- a/src/core/src/decorators/PostMapping.ts
+++ b/src/core/src/decorators/PostMapping.ts
@@ -1,0 +1,10 @@
+import 'reflect-metadata';
+
+export function PostMapping(value: any): MethodDecorator {
+  return (target: any, property: string | symbol, descriptor: PropertyDescriptor) => {
+    value.functionName = property;
+    const listMapping = Reflect.getMetadata('PostMapping', target) || [];
+    listMapping.push(value);
+    Reflect.defineMetadata('PostMapping', listMapping, target);
+  };
+}

--- a/src/core/src/decorators/PutMapping.ts
+++ b/src/core/src/decorators/PutMapping.ts
@@ -1,0 +1,10 @@
+import 'reflect-metadata';
+
+export function PutMapping(value: any): MethodDecorator {
+  return (target: any, property: string | symbol, descriptor: PropertyDescriptor) => {
+    value.functionName = property;
+    const listMapping = Reflect.getMetadata('PutMapping', target) || [];
+    listMapping.push(value);
+    Reflect.defineMetadata('PutMapping', listMapping, target);
+  };
+}

--- a/src/core/src/decorators/TyModule.ts
+++ b/src/core/src/decorators/TyModule.ts
@@ -25,11 +25,19 @@ export function TyModule<T>(value: ModuleWithProviders): ClassDecorator {
       value.declarations.map( (declaration) => {
         const controllerInstance = injector.resolve(declaration);
         Reflect.defineMetadata('moduleId', value.id, declaration);
-        const routes = Reflect.getMetadata( 'RequestMapping', controllerInstance) || [];
-        routes.map( (route: any) => {
-          Router.add(route.path, route.method, route.functionName, controllerInstance);
-          });
-        });
-      }
-    };
-  }
+        addRoutes(controllerInstance, 'RequestMapping', null);
+        addRoutes(controllerInstance, 'GetMapping', 'GET');
+        addRoutes(controllerInstance, 'PostMapping', 'POST');
+        addRoutes(controllerInstance, 'PutMapping', 'PUT');
+        addRoutes(controllerInstance, 'DeleteMapping', 'DELETE');
+      });
+    }
+  };
+}
+
+function addRoutes(controllerInstance: any, metadataKey: string, method: string | null) {
+  const routes = Reflect.getMetadata(metadataKey, controllerInstance) || [];
+  routes.map( (route: any) => {
+    Router.add(route.path, (method ? method : route.method), route.functionName, controllerInstance);
+  });
+}

--- a/src/core/src/decorators/index.ts
+++ b/src/core/src/decorators/index.ts
@@ -7,3 +7,7 @@ export { PathParam } from './PathParam';
 export { QueryParam } from './QueryParam';
 export { Body } from './Body';
 export { Response } from './Response';
+export { GetMapping } from './GetMapping';
+export { PostMapping } from './PostMapping';
+export { PutMapping } from './PutMapping';
+export { DeleteMapping } from './DeleteMapping';


### PR DESCRIPTION
…post, put et delete), comme dans Spring

C'est pour avoir comme Spring, pour éviter de devoir répéter les get, post etc... pour chaque path (et ça permet de ne pas se tromper en le tapant dans le code vu que la méthode est juste une string).

Par contre l'déal aurait été de mutualiser le contenu des fichiers GetMapping, PostMapping... parce que c'est exactement la même chose, à part la metadataKey. Mais je ne savais pas trop ou mettre ce code commun.

Qu'est-ce que tu en penses ?